### PR TITLE
Removed invalid macro reference

### DIFF
--- a/TA-cmdReporter/default/eventtypes.conf
+++ b/TA-cmdReporter/default/eventtypes.conf
@@ -314,7 +314,7 @@ search = (sourcetype=cmdreporter:network) socket_inet.ip_address="*" subject.aud
 
 # User network events
 [cmdrep_network_interactive_non-privileged]
-search = (`cmdrep_indexes` `cmdrep_sourcetype_network`) socket_inet.ip_address="*" subject.terminal_id.port!=0 NOT subject.audit_user_name="-1"
+search = (`cmdrep_indexes` sourcetype=cmdreporter:network) socket_inet.ip_address="*" subject.terminal_id.port!=0 NOT subject.audit_user_name="-1"
 
 
 #################################


### PR DESCRIPTION
Removed the cmdrep_sourcetype_network macro as it should have been removed in a previous cleanup.